### PR TITLE
support file size exceeding 2,147,483,647=0x7FFFFFFF

### DIFF
--- a/src/NFS3Prog.cpp
+++ b/src/NFS3Prog.cpp
@@ -657,7 +657,7 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
             if (offset == 0) {
                 _chsize(_fileno(pFile), 0);
             }
-            fseek(pFile, (long)offset, SEEK_SET);
+			_fseeki64( pFile, offset, SEEK_SET ) ;
             count = fwrite(data.contents, sizeof(char), data.length, pFile);
             fclose(pFile);
         } else {
@@ -1261,7 +1261,7 @@ nfsstat3 CNFS3Prog::ProcedureFSINFO(void)
             wtpref = 4096;
             wtmult = 512;
             dtpref = 8192;
-            maxfilesize = 0x7FFFFFFF;
+            maxfilesize = 0x7FFFFFFFFFFFFFFF;
             time_delta.seconds = 1;
             time_delta.nseconds = 0;
             properties = FSF3_CANSETTIME;

--- a/src/NFS3Prog.cpp
+++ b/src/NFS3Prog.cpp
@@ -597,7 +597,7 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
         errno_t errorNumber = fopen_s(&pFile, path, "rb");
 
         if (pFile != NULL) {
-            fseek(pFile, (long)offset, SEEK_SET);
+			_fseeki64( pFile, offset, SEEK_SET ) ;
             count = fread(data.contents, sizeof(char), count, pFile);
             eof = fgetc(pFile) == EOF;
             fclose(pFile);


### PR DESCRIPTION
I found this when I was doing "lseek" system call on a big file ( around 3GB ) at NFS client.
lseek system call check if seeking offset <= max size and return EINVAL if the condition is not satisfied.

As for "_fseeki64", it removes the limitation that read/write offset cannot exceed 0x7FFFFFFF.