### PR TITLE
Allow concurrent readers when opening files

### DIFF
--- a/src/NFS2Prog.cpp
+++ b/src/NFS2Prog.cpp
@@ -181,7 +181,7 @@ void CNFS2Prog::ProcedureREAD(void)
     m_pInStream->Read(&nCount);
     m_pInStream->Read(&nTotalCount);
 
-    errno_t error = fopen_s(&file, path, "rb");
+    file = _fsopen(path, "rb", _SH_DENYWR);
 
     if (file != NULL) {
         fseek(file, nOffset, SEEK_SET);
@@ -226,7 +226,7 @@ void CNFS2Prog::ProcedureWRITE(void)
     pBuffer = new char[nCount];
     m_pInStream->Read(pBuffer, nCount);
 
-    fopen_s(&file, path, "r+b");
+    file = _fsopen(path, "r+b", _SH_DENYWR);
 
     if (file != NULL) {
         fseek(file, nOffset, SEEK_SET);
@@ -254,7 +254,7 @@ void CNFS2Prog::ProcedureCREATE(void)
         return;
     }
 
-    fopen_s(&file, path, "wb");
+    file = _fsopen(path, "wb", _SH_DENYWR);
 
     if (file != NULL) {
         fclose(file);

--- a/src/NFS3Prog.cpp
+++ b/src/NFS3Prog.cpp
@@ -594,7 +594,7 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
 
     if (stat == NFS3_OK) {
         data.SetSize(count);
-        errno_t errorNumber = fopen_s(&pFile, path, "rb");
+        pFile = _fsopen(path, "rb", _SH_DENYWR);
 
         if (pFile != NULL) {
             fseek(pFile, (long)offset, SEEK_SET);
@@ -603,6 +603,7 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
             fclose(pFile);
         } else {
             char buffer[BUFFER_SIZE];
+            errno_t errorNumber = errno;
             strerror_s(buffer, BUFFER_SIZE, errorNumber);
             PrintLog(buffer);
 
@@ -651,7 +652,7 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
     file_wcc.before.attributes_follow = GetFileAttributesForNFS(path, &file_wcc.before.attributes);
 
     if (stat == NFS3_OK) {       
-        errno_t errorNumber = fopen_s(&pFile, path, "r+b");
+        pFile = _fsopen(path, "r+b", _SH_DENYWR);
 
         if (pFile != NULL) {
             if (offset == 0) {
@@ -662,6 +663,7 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
             fclose(pFile);
         } else {
             char buffer[BUFFER_SIZE];
+            errno_t errorNumber = errno;
             strerror_s(buffer, BUFFER_SIZE, errorNumber);
             PrintLog(buffer);
 
@@ -709,13 +711,14 @@ nfsstat3 CNFS3Prog::ProcedureCREATE(void)
 
     dir_wcc.before.attributes_follow = GetFileAttributesForNFS((char*)dirName.c_str(), &dir_wcc.before.attributes);
 
-    errno_t errorNumber = fopen_s(&pFile, path, "wb");
+    pFile = _fsopen(path, "wb", _SH_DENYWR);
        
     if (pFile != NULL) {
         fclose(pFile);
         stat = NFS3_OK;
     } else {
         char buffer[BUFFER_SIZE];
+        errno_t errorNumber = errno;
         strerror_s(buffer, BUFFER_SIZE, errorNumber);
         PrintLog(buffer);
 


### PR DESCRIPTION
The read, write and create operations use [`fopen_s`](https://msdn.microsoft.com/en-us/library/z5hh6ee9.aspx) to open the target file. Files opened in this way are not shareable. If the host has the file open, the client request will fail. If the client has the file open, it will not be possible to open the file on the host (even for reading).

I am using WinNFSd with Vagrant for a Ruby on Rails project with RubyMine. RubyMine opens the Rails log file for reading in order to display new log entries. However having the log open in this way prevents the Rails processes from writing to the log through WinNFSd.

This pull request changes the read, write and create operations to use [`_fsopen`](https://msdn.microsoft.com/en-us/library/8f30b0db.aspx) with a sharing flag of `_SH_DENYWR` instead of `fopen_s`. This will allow files to be opened concurrently for reading on the host.
