### PR TITLE
Fix mkdir error handling

### DIFF
--- a/src/NFS3Prog.cpp
+++ b/src/NFS3Prog.cpp
@@ -766,16 +766,16 @@ nfsstat3 CNFS3Prog::ProcedureMKDIR(void)
 
     dir_wcc.before.attributes_follow = GetFileAttributesForNFS((char*)dirName.c_str(), &dir_wcc.before.attributes);
 
-    errno_t errorNumber = _mkdir(path);
+    int result = _mkdir(path);
 
-    if (errorNumber == 0) {
+    if (result == 0) {
         stat = NFS3_OK;
         obj.handle_follows = GetFileHandle(path, &obj.handle);
         obj_attributes.attributes_follow = GetFileAttributesForNFS(path, &obj_attributes.attributes);
-    } else if (errorNumber == EEXIST) {
+    } else if (errno == EEXIST) {
         PrintLog("Directory already exists.");
         stat = NFS3ERR_EXIST;
-    } else if (errorNumber == ENOENT) {
+    } else if (errno == ENOENT) {
         stat = NFS3ERR_NOENT;
     } else {
         stat = CheckFile(path);


### PR DESCRIPTION
The [`_mkdir`](https://msdn.microsoft.com/en-us/library/2fkk4dzw.aspx) function returns 0 on success or -1 on error. When returning -1, `errno` is set to the error number.

`CNFS3Prog::ProcedureMKDIR` incorrectly treats the result of `_mkdir` as the error number, comparing it with `EEXIST` and `ENOENT`.

This pull request changes `ProcedureMKDIR` to use `errno` to obtain the error number.