### PR TITLE
Fix CFileTree::GetNodeFullPath memory leak

### DIFF
--- a/src/FileTable.cpp
+++ b/src/FileTable.cpp
@@ -48,7 +48,7 @@ CFileTable::~CFileTable()
     }
 }
 
-unsigned long CFileTable::GetIDByPath(char *path)
+unsigned long CFileTable::GetIDByPath(const char *path)
 {
     unsigned char *handle;
 
@@ -61,7 +61,7 @@ unsigned long CFileTable::GetIDByPath(char *path)
     return *(unsigned long *)handle;
 }
 
-unsigned char *CFileTable::GetHandleByPath(char *path)
+unsigned char *CFileTable::GetHandleByPath(const char *path)
 {
 	tree_node_<FILE_ITEM> *node;
 
@@ -83,7 +83,7 @@ unsigned char *CFileTable::GetHandleByPath(char *path)
 	return node->data.handle;
 }
 
-char *CFileTable::GetPathByHandle(unsigned char *handle)
+std::string CFileTable::GetPathByHandle(unsigned char *handle)
 {
 	unsigned int id;
 	tree_node_<FILE_ITEM>* node;
@@ -99,7 +99,7 @@ char *CFileTable::GetPathByHandle(unsigned char *handle)
     //return pItem == NULL ? NULL : pItem->path;
 }
 
-tree_node_<FILE_ITEM>* CFileTable::FindItemByPath(char *path)
+tree_node_<FILE_ITEM>* CFileTable::FindItemByPath(const char *path)
 {
 	tree_node_<FILE_ITEM>* node= NULL;/*
     CACHE_LIST *pCurr;
@@ -156,7 +156,7 @@ tree_node_<FILE_ITEM>* CFileTable::FindItemByPath(char *path)
 	return node;
 }
 
-tree_node_<FILE_ITEM>* CFileTable::AddItem(char *path)
+tree_node_<FILE_ITEM>* CFileTable::AddItem(const char *path)
 {
     FILE_ITEM item;
 	tree_node_<FILE_ITEM>* node;
@@ -256,7 +256,7 @@ void CFileTable::PutItemInCache(FILE_ITEM *pItem)
     }
 }
 
-bool CFileTable::RemoveItem(char *path) {
+bool CFileTable::RemoveItem(const char *path) {
    /* CACHE_LIST *pCurr;
     FILE_ITEM *pItem;
     unsigned int i, j, nPathLen;
@@ -317,7 +317,7 @@ bool CFileTable::RemoveItem(char *path) {
 		}
 		// Remove from table end
 
-		g_FileTree.RemoveItem(g_FileTree.GetNodeFullPath(foundDeletedItem));
+		g_FileTree.RemoveItem(g_FileTree.GetNodeFullPath(foundDeletedItem).c_str());
 		return true;
 	}
 	else {
@@ -326,7 +326,7 @@ bool CFileTable::RemoveItem(char *path) {
     return false;
 }
 
-void CFileTable::RenameFile(char *pathFrom, char* pathTo)
+void CFileTable::RenameFile(const char *pathFrom, const char* pathTo)
 {
 	/*FILE_ITEM *pItem;
 
@@ -343,7 +343,7 @@ void CFileTable::RenameFile(char *pathFrom, char* pathTo)
 	g_FileTree.RenameItem(pathFrom, pathTo);
 }
 
-bool FileExists(char *path)
+bool FileExists(const char *path)
 {
     int handle;
     struct _finddata_t fileinfo;
@@ -354,22 +354,22 @@ bool FileExists(char *path)
     return handle == -1 ? false : strcmp(fileinfo.name, strrchr(path, '\\') + 1) == 0;  //filename must match case
 }
 
-unsigned long GetFileID(char *path)
+unsigned long GetFileID(const char *path)
 {
     return g_FileTable.GetIDByPath(path);
 }
 
-unsigned char *GetFileHandle(char *path)
+unsigned char *GetFileHandle(const char *path)
 {
     return g_FileTable.GetHandleByPath(path);
 }
 
-char *GetFilePath(unsigned char *handle)
+std::string GetFilePath(unsigned char *handle)
 {
     return g_FileTable.GetPathByHandle(handle);
 }
 
-int RenameFile(char *pathFrom, char *pathTo)
+int RenameFile(const char *pathFrom, const char *pathTo)
 {
 	tree_node_<FILE_ITEM>* node;
     FILE_ITEM *pItem;
@@ -392,7 +392,7 @@ int RenameFile(char *pathFrom, char *pathTo)
     }
 }
 
-int RenameDirectory(char *pathFrom, char *pathTo)
+int RenameDirectory(const char *pathFrom, const char *pathTo)
 {
 	errno_t errorNumber = RenameFile(pathFrom, pathTo);
 
@@ -426,7 +426,7 @@ int RenameDirectory(char *pathFrom, char *pathTo)
 
 }
 
-bool RemoveFile(char *path)
+bool RemoveFile(const char *path)
 {
 	int nMode = 0;
 	nMode |= S_IREAD;
@@ -440,7 +440,7 @@ bool RemoveFile(char *path)
     return false;
 }
 
-int RemoveFolder(char *path)
+int RemoveFolder(const char *path)
 {
 	int nMode = 0;
 	unsigned long errorCode = 0;

--- a/src/FileTable.cpp
+++ b/src/FileTable.cpp
@@ -83,20 +83,20 @@ unsigned char *CFileTable::GetHandleByPath(const char *path)
 	return node->data.handle;
 }
 
-std::string CFileTable::GetPathByHandle(unsigned char *handle)
+bool CFileTable::GetPathByHandle(unsigned char *handle, std::string &path)
 {
 	unsigned int id;
 	tree_node_<FILE_ITEM>* node;
 
 	id = *(unsigned int *)handle;
-	// TODO : Not found item
+
 	node = GetItemByID(id);
 	if (node != NULL) {
-		return g_FileTree.GetNodeFullPath(node);
+		g_FileTree.GetNodeFullPath(node, path);
+        return true;
 	} else {
-		return NULL;
+		return false;
 	}
-    //return pItem == NULL ? NULL : pItem->path;
 }
 
 tree_node_<FILE_ITEM>* CFileTable::FindItemByPath(const char *path)
@@ -317,7 +317,9 @@ bool CFileTable::RemoveItem(const char *path) {
 		}
 		// Remove from table end
 
-		g_FileTree.RemoveItem(g_FileTree.GetNodeFullPath(foundDeletedItem).c_str());
+        std::string path;
+        g_FileTree.GetNodeFullPath(foundDeletedItem, path);
+		g_FileTree.RemoveItem(path.c_str());
 		return true;
 	}
 	else {
@@ -364,9 +366,9 @@ unsigned char *GetFileHandle(const char *path)
     return g_FileTable.GetHandleByPath(path);
 }
 
-std::string GetFilePath(unsigned char *handle)
+bool GetFilePath(unsigned char *handle, std::string &filePath)
 {
-    return g_FileTable.GetPathByHandle(handle);
+    return g_FileTable.GetPathByHandle(handle, filePath);
 }
 
 int RenameFile(const char *pathFrom, const char *pathTo)

--- a/src/FileTable.h
+++ b/src/FileTable.h
@@ -30,15 +30,15 @@ class CFileTable
     public:
     CFileTable();
     ~CFileTable();
-    unsigned long GetIDByPath(char *path);
-    unsigned char *GetHandleByPath(char *path);
-    char *GetPathByHandle(unsigned char *handle);
-	tree_node_<FILE_ITEM>* FindItemByPath(char *path);
-    bool RemoveItem(char *path);
-	void RenameFile(char *pathFrom, char *pathTo);
+    unsigned long GetIDByPath(const char *path);
+    unsigned char *GetHandleByPath(const char *path);
+    std::string GetPathByHandle(unsigned char *handle);
+	tree_node_<FILE_ITEM>* FindItemByPath(const char *path);
+    bool RemoveItem(const char *path);
+	void RenameFile(const char *pathFrom, const char *pathTo);
 
     protected:
-		tree_node_<FILE_ITEM>* AddItem(char *path);
+		tree_node_<FILE_ITEM>* AddItem(const char *path);
 
     private:
     FILE_TABLE *m_pFirstTable, *m_pLastTable;
@@ -50,12 +50,12 @@ class CFileTable
 
 };
 
-extern bool FileExists(char *path);
-extern unsigned long GetFileID(char *path);
-extern unsigned char *GetFileHandle(char *path);
-extern char *GetFilePath(unsigned char *handle);
-extern int RenameFile(char *pathFrom, char *pathTo);
-extern int RenameDirectory(char *pathFrom, char *pathTo);
-extern int RemoveFolder(char *path);
-extern bool RemoveFile(char *path);
+extern bool FileExists(const char *path);
+extern unsigned long GetFileID(const char *path);
+extern unsigned char *GetFileHandle(const char *path);
+extern std::string GetFilePath(unsigned char *handle);
+extern int RenameFile(const char *pathFrom, const char *pathTo);
+extern int RenameDirectory(const char *pathFrom, const char *pathTo);
+extern int RemoveFolder(const char *path);
+extern bool RemoveFile(const char *path);
 #endif

--- a/src/FileTable.h
+++ b/src/FileTable.h
@@ -32,7 +32,7 @@ class CFileTable
     ~CFileTable();
     unsigned long GetIDByPath(const char *path);
     unsigned char *GetHandleByPath(const char *path);
-    std::string GetPathByHandle(unsigned char *handle);
+    bool GetPathByHandle(unsigned char *handle, std::string &path);
 	tree_node_<FILE_ITEM>* FindItemByPath(const char *path);
     bool RemoveItem(const char *path);
 	void RenameFile(const char *pathFrom, const char *pathTo);
@@ -53,7 +53,7 @@ class CFileTable
 extern bool FileExists(const char *path);
 extern unsigned long GetFileID(const char *path);
 extern unsigned char *GetFileHandle(const char *path);
-extern std::string GetFilePath(unsigned char *handle);
+extern bool GetFilePath(unsigned char *handle, std::string &filePath);
 extern int RenameFile(const char *pathFrom, const char *pathTo);
 extern int RenameDirectory(const char *pathFrom, const char *pathTo);
 extern int RemoveFolder(const char *path);

--- a/src/FileTree.cpp
+++ b/src/FileTree.cpp
@@ -81,7 +81,7 @@ std::string _basename_932(std::string path) {
 	return result;
 }
 
-FILE_ITEM CFileTree::AddItem(char *absolutePath, unsigned char* handle)
+FILE_ITEM CFileTree::AddItem(const char *absolutePath, unsigned char* handle)
 {
 	FILE_ITEM item;
 	item.handle = handle;
@@ -125,7 +125,7 @@ FILE_ITEM CFileTree::AddItem(char *absolutePath, unsigned char* handle)
 	return item;
 }
 
-void CFileTree::RemoveItem(char *absolutePath)
+void CFileTree::RemoveItem(const char *absolutePath)
 {
 	tree_node_<FILE_ITEM>* node = findNodeFromRootWithPath(absolutePath);
 	if (node != NULL) {
@@ -138,7 +138,7 @@ void CFileTree::RemoveItem(char *absolutePath)
 	DisplayTree(topNode.node, 0);
 }
 
-void CFileTree::RenameItem(char *absolutePathFrom, char *absolutePathTo)
+void CFileTree::RenameItem(const char *absolutePathFrom, const char *absolutePathTo)
 {
 	tree_node_<FILE_ITEM>* node = findNodeFromRootWithPath(absolutePathFrom);
 	tree_node_<FILE_ITEM>* parentNode = findParentNodeFromRootForPath(absolutePathTo);
@@ -162,7 +162,7 @@ void CFileTree::RenameItem(char *absolutePathFrom, char *absolutePathTo)
 	DisplayTree(topNode.node, 0);
 }
 
-tree_node_<FILE_ITEM>* CFileTree::FindFileItemForPath(char *absolutePath)
+tree_node_<FILE_ITEM>* CFileTree::FindFileItemForPath(const char *absolutePath)
 {
 	tree_node_<FILE_ITEM>* node = findNodeFromRootWithPath(absolutePath);
 	if (node == NULL) {
@@ -171,7 +171,7 @@ tree_node_<FILE_ITEM>* CFileTree::FindFileItemForPath(char *absolutePath)
 	return node;
 }
 
-tree_node_<FILE_ITEM>* CFileTree::findNodeFromRootWithPath(char *path)
+tree_node_<FILE_ITEM>* CFileTree::findNodeFromRootWithPath(const char *path)
 {
 	// No topNode - bail out.
 	if (topNode.node == NULL){
@@ -190,7 +190,7 @@ tree_node_<FILE_ITEM>* CFileTree::findNodeFromRootWithPath(char *path)
 	if (sPath.find(nPath) != std::string::npos) {
 		// printf("Found %s is part of %s  \n", sPath.c_str(), topNode->path);
 		std::string splittedString = sPath.substr(strlen(topNode->path) + 1);
-		return findNodeWithPathFromNode(splittedString, topNode.node);
+		return findNodeWithPathFromNode(splittedString.c_str(), topNode.node);
 	}
 	else {
 		// If the current topNode isn't related to the requested path
@@ -214,7 +214,7 @@ tree_node_<FILE_ITEM>* CFileTree::findNodeFromRootWithPath(char *path)
 				// printf("Found root node %s \n", it.node->data.path);
 				topNode = it;
 				std::string splittedString = sPath.substr(itPath.length() + 1);
-				return findNodeWithPathFromNode(splittedString, it.node);
+				return findNodeWithPathFromNode(splittedString.c_str(), it.node);
 			}
 		}
 	}
@@ -222,7 +222,7 @@ tree_node_<FILE_ITEM>* CFileTree::findNodeFromRootWithPath(char *path)
 	return NULL;
 }
 
-tree_node_<FILE_ITEM>* CFileTree::findNodeWithPathFromNode(std::string path, tree_node_<FILE_ITEM>* node)
+tree_node_<FILE_ITEM>* CFileTree::findNodeWithPathFromNode(const char *path, tree_node_<FILE_ITEM>* node)
 {
 	tree<FILE_ITEM>::sibling_iterator sib = filesTree.begin(node);
 	tree<FILE_ITEM>::sibling_iterator end = filesTree.end(node);
@@ -241,7 +241,7 @@ tree_node_<FILE_ITEM>* CFileTree::findNodeWithPathFromNode(std::string path, tre
 				return sib.node;
 			}
 			else {
-				return findNodeWithPathFromNode(followingPath, sib.node);
+				return findNodeWithPathFromNode(followingPath.c_str(), sib.node);
 			}
 		}
 		++sib;
@@ -249,7 +249,7 @@ tree_node_<FILE_ITEM>* CFileTree::findNodeWithPathFromNode(std::string path, tre
 	return NULL;
 }
 
-tree_node_<FILE_ITEM>* CFileTree::findParentNodeFromRootForPath(char *path) {
+tree_node_<FILE_ITEM>* CFileTree::findParentNodeFromRootForPath(const char *path) {
 	std::string sPath(path);
 	std::string nPath(topNode->path);
 
@@ -265,11 +265,11 @@ tree_node_<FILE_ITEM>* CFileTree::findParentNodeFromRootForPath(char *path) {
 	if (followingPath.empty()) {
 		return topNode.node;
 	} else {
-		return findNodeWithPathFromNode(followingPath, topNode.node);
+		return findNodeWithPathFromNode(followingPath.c_str(), topNode.node);
 	}
 }
 
-char* CFileTree::GetNodeFullPath(tree_node_<FILE_ITEM>* node)
+std::string CFileTree::GetNodeFullPath(tree_node_<FILE_ITEM>* node)
 {
 	std::string path;
 	path.append(node->data.path);
@@ -281,10 +281,7 @@ char* CFileTree::GetNodeFullPath(tree_node_<FILE_ITEM>* node)
 		parentNode = parentNode->parent;
 	}
 
-	// TODO : Memory leak
-	char *cstr = new char[path.length() + 1];
-	strcpy_s(cstr, path.length() + 1, path.c_str());
-	return cstr;
+    return path;
 }
 
 void DisplayTree(tree_node_<FILE_ITEM>* node, int level)

--- a/src/FileTree.cpp
+++ b/src/FileTree.cpp
@@ -269,9 +269,8 @@ tree_node_<FILE_ITEM>* CFileTree::findParentNodeFromRootForPath(const char *path
 	}
 }
 
-std::string CFileTree::GetNodeFullPath(tree_node_<FILE_ITEM>* node)
+void CFileTree::GetNodeFullPath(tree_node_<FILE_ITEM>* node, std::string &path)
 {
-	std::string path;
 	path.append(node->data.path);
 	tree_node_<FILE_ITEM>* parentNode = node->parent;
 	while (parentNode != NULL)
@@ -280,8 +279,6 @@ std::string CFileTree::GetNodeFullPath(tree_node_<FILE_ITEM>* node)
 		path.insert(0, parentNode->data.path);
 		parentNode = parentNode->parent;
 	}
-
-    return path;
 }
 
 void DisplayTree(tree_node_<FILE_ITEM>* node, int level)

--- a/src/FileTree.h
+++ b/src/FileTree.h
@@ -13,7 +13,7 @@ class CFileTree
 
 		tree_node_<FILE_ITEM>* FindFileItemForPath(const char *absolutePath);
 
-        std::string GetNodeFullPath(tree_node_<FILE_ITEM>* node);
+        void GetNodeFullPath(tree_node_<FILE_ITEM>* node, std::string &fullPath);
 		
 	protected:
 		tree_node_<FILE_ITEM>* findNodeFromRootWithPath(const char *path);

--- a/src/FileTree.h
+++ b/src/FileTree.h
@@ -7,18 +7,18 @@ class CFileTree
 {
 	public:
 		bool static const debug = false;
-		FILE_ITEM AddItem(char *absolutePath, unsigned char *handle);
-		void RemoveItem(char *absolutePath);
-		void RenameItem(char *absolutePathFrom, char *absolutePathTo);
+		FILE_ITEM AddItem(const char *absolutePath, unsigned char *handle);
+		void RemoveItem(const char *absolutePath);
+		void RenameItem(const char *absolutePathFrom, const char *absolutePathTo);
 
-		tree_node_<FILE_ITEM>* FindFileItemForPath(char *absolutePath);
+		tree_node_<FILE_ITEM>* FindFileItemForPath(const char *absolutePath);
 
-		char * GetNodeFullPath(tree_node_<FILE_ITEM>* node);
+        std::string GetNodeFullPath(tree_node_<FILE_ITEM>* node);
 		
 	protected:
-		tree_node_<FILE_ITEM>* findNodeFromRootWithPath(char *path);
-		tree_node_<FILE_ITEM>* findNodeWithPathFromNode(std::string path, tree_node_<FILE_ITEM>* node);
-		tree_node_<FILE_ITEM>* findParentNodeFromRootForPath(char *path);
+		tree_node_<FILE_ITEM>* findNodeFromRootWithPath(const char *path);
+		tree_node_<FILE_ITEM>* findNodeWithPathFromNode(const char *path, tree_node_<FILE_ITEM>* node);
+		tree_node_<FILE_ITEM>* findParentNodeFromRootForPath(const char *path);
 };
 extern void DisplayTree(tree_node_<FILE_ITEM>* node, int level);
 

--- a/src/MountProg.cpp
+++ b/src/MountProg.cpp
@@ -53,7 +53,7 @@ CMountProg::~CMountProg()
 
 }
 
-bool CMountProg::SetPathFile(char *file)
+bool CMountProg::SetPathFile(const char *file)
 {
 	char *formattedFile = FormatPath(file, FORMAT_PATH);
 
@@ -77,7 +77,7 @@ bool CMountProg::SetPathFile(char *file)
 	return false;
 }
 
-void CMountProg::Export(char *path, char *pathAlias)
+void CMountProg::Export(const char *path, const char *pathAlias)
 {
 	char *formattedPath = FormatPath(path, FORMAT_PATH);
 	pathAlias = FormatPath(pathAlias, FORMAT_PATHALIAS);
@@ -348,7 +348,7 @@ bool CMountProg::GetPath(char **returnPath)
 }
 
 
-bool CMountProg::ReadPathsFromFile(char* sFileName)
+bool CMountProg::ReadPathsFromFile(const char* sFileName)
 {
 	std::ifstream pathFile(sFileName);
 
@@ -396,7 +396,7 @@ bool CMountProg::ReadPathsFromFile(char* sFileName)
 	return true;
 }
 
-char *CMountProg::FormatPath(char *pPath, pathFormats format)
+char *CMountProg::FormatPath(const char *pPath, pathFormats format)
 {
     size_t len = strlen(pPath);
 
@@ -484,15 +484,15 @@ char *CMountProg::FormatPath(char *pPath, pathFormats format)
 		}
 	} else if (format == FORMAT_PATHALIAS) {
 		if (pPath[1] == ':' && ((pPath[0] >= 'A' && pPath[0] <= 'Z') || (pPath[0] >= 'a' && pPath[0] <= 'z'))) {
+            strncpy_s(result, len + 1, pPath, len);
 			//transform Windows format to mount path d:\work => /d/work
-			pPath[1] = pPath[0];
-			pPath[0] = '/';
-			for (size_t i = 2; i < strlen(pPath); i++) {
-				if (pPath[i] == '\\') {
-					pPath[i] = '/';
+            result[1] = result[0];
+            result[0] = '/';
+			for (size_t i = 2; i < strlen(result); i++) {
+				if (result[i] == '\\') {
+                    result[i] = '/';
 				}
 			}
-			strncpy_s(result, len + 1, pPath, len);
 		} else if (pPath[0] != '/') { //check path alias format
 			printf("Path alias format is incorrect.\n");
 			printf("Please use a path like /exports\n");

--- a/src/MountProg.h
+++ b/src/MountProg.h
@@ -19,13 +19,13 @@ class CMountProg : public CRPCProg
     public:
     CMountProg();
     virtual ~CMountProg();
-	bool SetPathFile(char *file);
-    void Export(char *path, char *pathAlias);
+	bool SetPathFile(const char *file);
+    void Export(const char *path, const char *pathAlias);
 	bool Refresh();
     char *GetClientAddr(int nIndex);
     int GetMountNumber(void);
     int Process(IInputStream *pInStream, IOutputStream *pOutStream, ProcessParam *pParam);
-	char *FormatPath(char *pPath, pathFormats format);
+	char *FormatPath(const char *pPath, pathFormats format);
 
     protected:
     int m_nMountNum;
@@ -48,7 +48,7 @@ class CMountProg : public CRPCProg
 
 	bool GetPath(char **returnPath);
     char *GetPath(int &pathNumber);
-	bool ReadPathsFromFile(char* sFileName);
+	bool ReadPathsFromFile(const char* sFileName);
 };
 
 #endif

--- a/src/NFS3Prog.cpp
+++ b/src/NFS3Prog.cpp
@@ -374,13 +374,14 @@ nfsstat3 CNFS3Prog::ProcedureGETATTR(void)
     nfsstat3 stat;
 
     PrintLog("GETATTR");
-    path = GetPath();
-    stat = CheckFile(path.c_str());
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
+    stat = CheckFile(cStr);
 	//printf("\nscanned file %s\n", path);
     if (stat == NFS3ERR_NOENT) {
         stat = NFS3ERR_STALE;
     } else if (stat == NFS3_OK) {
-        if (!GetFileAttributesForNFS(path.c_str(), &obj_attributes)) {
+        if (!GetFileAttributesForNFS(cStr, &obj_attributes)) {
             stat = NFS3ERR_IO;
         }
     }
@@ -408,11 +409,12 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
     SYSTEMTIME systemTime;
 
     PrintLog("SETATTR");
-    path = GetPath();
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
     Read(&new_attributes);
     Read(&guard);
-    stat = CheckFile(path.c_str());
-    obj_wcc.before.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_wcc.before.attributes);
+    stat = CheckFile(cStr);
+    obj_wcc.before.attributes_follow = GetFileAttributesForNFS(cStr, &obj_wcc.before.attributes);
 
     if (stat == NFS3_OK) {
         if (new_attributes.mode.set_it) {
@@ -432,7 +434,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
             //     nMode |= S_IEXEC;
             // }
 
-            if (_chmod(path.c_str(), nMode) != 0) {
+            if (_chmod(cStr, nMode) != 0) {
                 stat = NFS3ERR_INVAL;
             } else {
 
@@ -448,7 +450,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
         if (new_attributes.atime.set_it == SET_TO_CLIENT_TIME){}
 
         if (new_attributes.mtime.set_it == SET_TO_SERVER_TIME || new_attributes.atime.set_it == SET_TO_SERVER_TIME){
-            hFile = CreateFile(path.c_str(), FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
+            hFile = CreateFile(cStr, FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
             if (hFile != INVALID_HANDLE_VALUE) {
                 GetSystemTime(&systemTime);
                 SystemTimeToFileTime(&systemTime, &fileTime);
@@ -463,7 +465,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
         }
 
         if (new_attributes.size.set_it){
-            pFile = _fsopen(path.c_str(), "r+b", _SH_DENYWR);
+            pFile = _fsopen(cStr, "r+b", _SH_DENYWR);
             if (pFile != NULL) {
                 int filedes = _fileno(pFile);
                 _chsize_s(filedes, new_attributes.size.size);
@@ -472,7 +474,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
         }
     }
 
-    obj_wcc.after.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_wcc.after.attributes);
+    obj_wcc.after.attributes_follow = GetFileAttributesForNFS(cStr, &obj_wcc.after.attributes);
 
     Write(&stat);
     Write(&obj_wcc);
@@ -524,15 +526,16 @@ nfsstat3 CNFS3Prog::ProcedureACCESS(void)
     nfsstat3 stat;
 
     PrintLog("ACCESS");
-    path = GetPath();
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
     Read(&access);
-    stat = CheckFile(path.c_str());
+    stat = CheckFile(cStr);
 
     if (stat == NFS3ERR_NOENT) {
         stat = NFS3ERR_STALE;
     }
 
-    obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
+    obj_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &obj_attributes.attributes);
 
     Write(&stat);
     Write(&obj_attributes);
@@ -561,11 +564,12 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
     lpOutBuffer = (REPARSE_DATA_BUFFER*)malloc(MAXIMUM_REPARSE_DATA_BUFFER_SIZE);
     DWORD bytesReturned;
 
-    path = GetPath();
-    stat = CheckFile(path.c_str());
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
+    stat = CheckFile(cStr);
     if (stat == NFS3_OK) {
 
-        hFile = CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_REPARSE_POINT | FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+        hFile = CreateFile(cStr, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_REPARSE_POINT | FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
 
         if (hFile == INVALID_HANDLE_VALUE) {
             stat = NFS3ERR_IO;
@@ -604,7 +608,7 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
                                 path = path.substr(0, lastFolderIndex);
                             }
                             char szOut[MAX_PATH] = "";
-                            PathRelativePathTo(szOut, path.c_str(), FILE_ATTRIBUTE_DIRECTORY, target, FILE_ATTRIBUTE_DIRECTORY);
+                            PathRelativePathTo(szOut, cStr, FILE_ATTRIBUTE_DIRECTORY, target, FILE_ATTRIBUTE_DIRECTORY);
                             std::string symlinkPath(szOut);
                             finalSymlinkPath.assign(symlinkPath);
                         }
@@ -628,7 +632,7 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
                             path = path.substr(0, lastFolderIndex);
                         }
                         char szOut[MAX_PATH] = "";
-                        PathRelativePathTo(szOut, path.c_str(), FILE_ATTRIBUTE_DIRECTORY, target.c_str(), FILE_ATTRIBUTE_DIRECTORY);
+                        PathRelativePathTo(szOut, cStr, FILE_ATTRIBUTE_DIRECTORY, target.c_str(), FILE_ATTRIBUTE_DIRECTORY);
                         std::string symlinkPath = szOut;
                         finalSymlinkPath.assign(symlinkPath);
                     }
@@ -644,7 +648,7 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
         CloseHandle(hFile);
     }
 
-    symlink_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &symlink_attributes.attributes);
+    symlink_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &symlink_attributes.attributes);
 
     Write(&stat);
     Write(&symlink_attributes);
@@ -667,14 +671,15 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
     FILE *pFile;
 
     PrintLog("READ");
-    path = GetPath();
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
     Read(&offset);
     Read(&count);
-    stat = CheckFile(path.c_str());
+    stat = CheckFile(cStr);
 
     if (stat == NFS3_OK) {
         data.SetSize(count);
-        pFile = _fsopen(path.c_str(), "rb", _SH_DENYWR);
+        pFile = _fsopen(cStr, "rb", _SH_DENYWR);
 
         if (pFile != NULL) {
             _fseeki64(pFile, offset, SEEK_SET) ;
@@ -695,7 +700,7 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
         }
     }
 
-    file_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_attributes.attributes);
+    file_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &file_attributes.attributes);
 
     Write(&stat);
     Write(&file_attributes);
@@ -722,24 +727,25 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
     FILE *pFile;
 
     PrintLog("WRITE");
-    path = GetPath();
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
     Read(&offset);
     Read(&count);
     Read(&stable);
     Read(&data);
-    stat = CheckFile(path.c_str());
+    stat = CheckFile(cStr);
 
-    file_wcc.before.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.before.attributes);
+    file_wcc.before.attributes_follow = GetFileAttributesForNFS(cStr, &file_wcc.before.attributes);
 
     if (stat == NFS3_OK) {
 
         if (stable == UNSTABLE) {
             nfs_fh3 handle;
-            GetFileHandle(path.c_str(), &handle);
+            GetFileHandle(cStr, &handle);
             int handleId = *(unsigned int *)handle.contents;
 
             if (unstableStorageFile.count(handleId) == 0){
-                pFile = _fsopen(path.c_str(), "r+b", _SH_DENYWR);
+                pFile = _fsopen(cStr, "r+b", _SH_DENYWR);
                 if (pFile != NULL) {
                     unstableStorageFile.insert(std::make_pair(handleId, pFile));
                 }
@@ -769,7 +775,7 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
             file_wcc.after.attributes_follow = file_wcc.before.attributes_follow;
         } else {
 
-            pFile = _fsopen(path.c_str(), "r+b", _SH_DENYWR);
+            pFile = _fsopen(cStr, "r+b", _SH_DENYWR);
 
             if (pFile != NULL) {
                 _fseeki64(pFile, offset, SEEK_SET) ;
@@ -791,7 +797,7 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
             stable = FILE_SYNC;
             verf = 0;
 
-            file_wcc.after.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.after.attributes);
+            file_wcc.after.attributes_follow = GetFileAttributesForNFS(cStr, &file_wcc.after.attributes);
         }
     }
 
@@ -956,7 +962,7 @@ nfsstat3 CNFS3Prog::ProcedureSYMLINK(void)
     // Relative path do not work with GetFileAttributes (directory are not recognized)
     // so we normalize the path before calling GetFileAttributes
     TCHAR fullTargetPathNormalized[MAX_PATH];
-    _In_ LPTSTR fullTargetPathString = const_cast<LPSTR>(fullTargetPath.c_str());;
+    _In_ LPTSTR fullTargetPathString = const_cast<LPSTR>(fullTargetPath.c_str());
     GetFullPathName(fullTargetPathString, MAX_PATH, fullTargetPathNormalized, NULL);
     targetFileAttr = GetFileAttributes(fullTargetPathNormalized);
 
@@ -1162,17 +1168,19 @@ nfsstat3 CNFS3Prog::ProcedureLINK(void)
     post_op_attr obj_attributes;
     wcc_data dir_wcc;
 
-    path = GetPath();
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
     ReadDirectory(dirName, fileName);
 
     char *linkFullPath = GetFullPath(dirName, fileName);
 
-    if (CreateHardLink(linkFullPath, path.c_str(), NULL) == 0) {
+    //TODO: Improve checks here, cStr may be NULL because handle is invalid
+    if (CreateHardLink(linkFullPath, cStr, NULL) == 0) {
         stat = NFS3ERR_IO;
     }
     stat = CheckFile(linkFullPath);
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &obj_attributes.attributes);
 
         if (!obj_attributes.attributes_follow) {
             stat = NFS3ERR_IO;
@@ -1206,14 +1214,15 @@ nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
     unsigned int i, j;
 
     PrintLog("READDIR");
-    path = GetPath();
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
     Read(&cookie);
     Read(&cookieverf);
     Read(&count);
-    stat = CheckFile(path.c_str());
+    stat = CheckFile(cStr);
 
     if (stat == NFS3_OK) {
-        dir_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &dir_attributes.attributes);
+        dir_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &dir_attributes.attributes);
 
         if (!dir_attributes.attributes_follow) {
             stat = NFS3ERR_IO;
@@ -1225,7 +1234,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
 
     if (stat == NFS3_OK) {
         Write(&cookieverf);
-        sprintf_s(filePath, "%s\\*", path.c_str());
+        sprintf_s(filePath, "%s\\*", cStr);
         eof = true;
         handle = _findfirst(filePath, &fileinfo);
         bFollows = true;
@@ -1244,7 +1253,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
 
                 do {
                     Write(&bFollows); //value follows
-                    sprintf_s(filePath, "%s\\%s", path.c_str(), fileinfo.name);
+                    sprintf_s(filePath, "%s\\%s", cStr, fileinfo.name);
                     fileid = GetFileID(filePath);
                     Write(&fileid); //file id
                     name.Set(fileinfo.name);
@@ -1289,15 +1298,16 @@ nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
     bool bFollows;
 
     PrintLog("READDIRPLUS");
-    path = GetPath();
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
     Read(&cookie);
     Read(&cookieverf);
     Read(&dircount);
     Read(&maxcount);
-    stat = CheckFile(path.c_str());
+    stat = CheckFile(cStr);
 
     if (stat == NFS3_OK) {
-        dir_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &dir_attributes.attributes);
+        dir_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &dir_attributes.attributes);
         
         if (!dir_attributes.attributes_follow) {
             stat = NFS3ERR_IO;
@@ -1309,7 +1319,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
 
     if (stat == NFS3_OK) {
         Write(&cookieverf);
-        sprintf_s(filePath, "%s\\*", path.c_str());
+        sprintf_s(filePath, "%s\\*", cStr);
         handle = _findfirst(filePath, &fileinfo);
         eof = true;
 
@@ -1326,7 +1336,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
 
                 do {
                     Write(&bFollows); //value follows
-                    sprintf_s(filePath, "%s\\%s", path.c_str(), fileinfo.name);
+                    sprintf_s(filePath, "%s\\%s", cStr, fileinfo.name);
                     fileid = GetFileID(filePath);
                     Write(&fileid); //file id
                     name.Set(fileinfo.name);
@@ -1366,14 +1376,15 @@ nfsstat3 CNFS3Prog::ProcedureFSSTAT(void)
     nfsstat3 stat;
 
     PrintLog("FSSTAT");
-    path = GetPath();
-    stat = CheckFile(path.c_str());
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
+    stat = CheckFile(cStr);
 
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &obj_attributes.attributes);
 
         if (obj_attributes.attributes_follow
-            && GetDiskFreeSpaceEx(path.c_str(), (PULARGE_INTEGER)&fbytes, (PULARGE_INTEGER)&tbytes, (PULARGE_INTEGER)&abytes)
+            && GetDiskFreeSpaceEx(cStr, (PULARGE_INTEGER)&fbytes, (PULARGE_INTEGER)&tbytes, (PULARGE_INTEGER)&abytes)
             ) {
             //tfiles = 99999999999;
             //ffiles = 99999999999;
@@ -1411,11 +1422,12 @@ nfsstat3 CNFS3Prog::ProcedureFSINFO(void)
     nfsstat3 stat;
 
     PrintLog("FSINFO");
-    path = GetPath();
-    stat = CheckFile(path.c_str());
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
+    stat = CheckFile(cStr);
 
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &obj_attributes.attributes);
 
         if (obj_attributes.attributes_follow) {
             rtmax = 65536;
@@ -1462,11 +1474,12 @@ nfsstat3 CNFS3Prog::ProcedurePATHCONF(void)
     bool no_trunc, chown_restricted, case_insensitive, case_preserving;
 
     PrintLog("PATHCONF");
-    path = GetPath();
-    stat = CheckFile(path.c_str());
+    bool validHandle = GetPath(path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
+    stat = CheckFile(cStr);
 
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(cStr, &obj_attributes.attributes);
 
         if (obj_attributes.attributes_follow) {
             linkmax = 1023;
@@ -1508,7 +1521,12 @@ nfsstat3 CNFS3Prog::ProcedureCOMMIT(void)
 
     PrintLog("COMMIT");
     Read(&file);
-    path = GetFilePath(file.contents);
+    bool validHandle = GetFilePath(file.contents, path);
+    const char* cStr = validHandle ? path.c_str() : NULL;
+
+    if (validHandle) {
+        PrintLog(" %s ", path.c_str());
+    }
 
     // offset and count are unused
     // offset never was anything else than 0 in my tests
@@ -1517,7 +1535,7 @@ nfsstat3 CNFS3Prog::ProcedureCOMMIT(void)
     Read(&offset);
     Read(&count);
 
-    file_wcc.before.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.before.attributes);
+    file_wcc.before.attributes_follow = GetFileAttributesForNFS(cStr, &file_wcc.before.attributes);
 
     handleId = *(unsigned int*)file.contents;
 
@@ -1529,7 +1547,7 @@ nfsstat3 CNFS3Prog::ProcedureCOMMIT(void)
         stat = NFS3ERR_IO;
     }
 
-    file_wcc.after.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.after.attributes);
+    file_wcc.after.attributes_follow = GetFileAttributesForNFS(cStr, &file_wcc.after.attributes);
 
     Write(&stat);
     Write(&file_wcc);
@@ -1768,37 +1786,34 @@ void CNFS3Prog::Write(wcc_attr *pAttr)
     Write(&pAttr->ctime);
 }
 
-std::string CNFS3Prog::GetPath(void)
+bool CNFS3Prog::GetPath(std::string &path)
 {
     nfs_fh3 object;
-    std::string path;
 
     Read(&object);
-    path = GetFilePath(object.contents);
-    PrintLog(" %s ", path.c_str());
+    bool valid = GetFilePath(object.contents, path);
+    if (valid) {
+        PrintLog(" %s ", path.c_str());
+    } else {
+        PrintLog(" File handle is invalid ");
+    }
 
-    return path;
+    return valid;
 }
 
-void CNFS3Prog::ReadDirectory(std::string &dirName, std::string &fileName)
+bool CNFS3Prog::ReadDirectory(std::string &dirName, std::string &fileName)
 {
     diropargs3 fileRequest;
     Read(&fileRequest);
 
-    dirName = std::string(GetFilePath(fileRequest.dir.contents));
-    fileName = std::string(fileRequest.name.name);
+    if (GetFilePath(fileRequest.dir.contents, dirName)) {
+        fileName = std::string(fileRequest.name.name);
+        return true;
+    } else {
+        return false;
+    }
 
     //PrintLog(" %s | %s ", dirName.c_str(), fileName.c_str());
-}
-
-char *CNFS3Prog::GetFullPath(void)
-{
-    //TODO: Return std::string
-    std::string dirName;
-    std::string fileName;
-
-    ReadDirectory(dirName, fileName);
-    return GetFullPath(dirName, fileName);
 }
 
 char *CNFS3Prog::GetFullPath(std::string &dirName, std::string &fileName)

--- a/src/NFS3Prog.cpp
+++ b/src/NFS3Prog.cpp
@@ -369,18 +369,18 @@ nfsstat3 CNFS3Prog::ProcedureNULL(void)
 
 nfsstat3 CNFS3Prog::ProcedureGETATTR(void)
 {
-    char *path;
+    std::string path;
     fattr3 obj_attributes;
     nfsstat3 stat;
 
     PrintLog("GETATTR");
     path = GetPath();
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 	//printf("\nscanned file %s\n", path);
     if (stat == NFS3ERR_NOENT) {
         stat = NFS3ERR_STALE;
     } else if (stat == NFS3_OK) {
-        if (!GetFileAttributesForNFS(path, &obj_attributes)) {
+        if (!GetFileAttributesForNFS(path.c_str(), &obj_attributes)) {
             stat = NFS3ERR_IO;
         }
     }
@@ -396,7 +396,7 @@ nfsstat3 CNFS3Prog::ProcedureGETATTR(void)
 
 nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
 {
-    char *path;
+    std::string path;
     sattr3 new_attributes;
     sattrguard3 guard;
     wcc_data obj_wcc;
@@ -411,8 +411,8 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
     path = GetPath();
     Read(&new_attributes);
     Read(&guard);
-    stat = CheckFile(path);
-    obj_wcc.before.attributes_follow = GetFileAttributesForNFS(path, &obj_wcc.before.attributes);
+    stat = CheckFile(path.c_str());
+    obj_wcc.before.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_wcc.before.attributes);
 
     if (stat == NFS3_OK) {
         if (new_attributes.mode.set_it) {
@@ -432,7 +432,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
             //     nMode |= S_IEXEC;
             // }
 
-            if (_chmod(path, nMode) != 0) {
+            if (_chmod(path.c_str(), nMode) != 0) {
                 stat = NFS3ERR_INVAL;
             } else {
 
@@ -448,7 +448,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
         if (new_attributes.atime.set_it == SET_TO_CLIENT_TIME){}
 
         if (new_attributes.mtime.set_it == SET_TO_SERVER_TIME || new_attributes.atime.set_it == SET_TO_SERVER_TIME){
-            hFile = CreateFile(path, FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
+            hFile = CreateFile(path.c_str(), FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
             if (hFile != INVALID_HANDLE_VALUE) {
                 GetSystemTime(&systemTime);
                 SystemTimeToFileTime(&systemTime, &fileTime);
@@ -463,7 +463,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
         }
 
         if (new_attributes.size.set_it){
-            pFile = _fsopen(path, "r+b", _SH_DENYWR);
+            pFile = _fsopen(path.c_str(), "r+b", _SH_DENYWR);
             if (pFile != NULL) {
                 int filedes = _fileno(pFile);
                 _chsize_s(filedes, new_attributes.size.size);
@@ -472,7 +472,7 @@ nfsstat3 CNFS3Prog::ProcedureSETATTR(void)
         }
     }
 
-    obj_wcc.after.attributes_follow = GetFileAttributesForNFS(path, &obj_wcc.after.attributes);
+    obj_wcc.after.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_wcc.after.attributes);
 
     Write(&stat);
     Write(&obj_wcc);
@@ -518,7 +518,7 @@ nfsstat3 CNFS3Prog::ProcedureLOOKUP(void)
 
 nfsstat3 CNFS3Prog::ProcedureACCESS(void)
 {
-    char *path;
+    std::string path;
     uint32 access;
     post_op_attr obj_attributes;
     nfsstat3 stat;
@@ -526,13 +526,13 @@ nfsstat3 CNFS3Prog::ProcedureACCESS(void)
     PrintLog("ACCESS");
     path = GetPath();
     Read(&access);
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
     if (stat == NFS3ERR_NOENT) {
         stat = NFS3ERR_STALE;
     }
 
-    obj_attributes.attributes_follow = GetFileAttributesForNFS(path, &obj_attributes.attributes);
+    obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
 
     Write(&stat);
     Write(&obj_attributes);
@@ -547,7 +547,7 @@ nfsstat3 CNFS3Prog::ProcedureACCESS(void)
 nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
 {
     PrintLog("READLINK");
-    char *path;
+    std::string path;
     char *pMBBuffer = 0;
 
     post_op_attr symlink_attributes;
@@ -562,10 +562,10 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
     DWORD bytesReturned;
 
     path = GetPath();
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
     if (stat == NFS3_OK) {
 
-        hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_REPARSE_POINT | FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+        hFile = CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_REPARSE_POINT | FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
 
         if (hFile == INVALID_HANDLE_VALUE) {
             stat = NFS3ERR_IO;
@@ -599,12 +599,12 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
                             strFromChar.append(cPrintName);
                             char *target = _strdup(strFromChar.c_str());
                             // remove last folder
-                            char *pos = strrchr(path, '\\');
-                            if (pos != NULL) {
-                                *pos = '\0';
+                            size_t lastFolderIndex = path.find_last_of('\\');
+                            if (lastFolderIndex != std::string::npos) {
+                                path = path.substr(0, lastFolderIndex);
                             }
                             char szOut[MAX_PATH] = "";
-                            PathRelativePathTo(szOut, path, FILE_ATTRIBUTE_DIRECTORY, target, FILE_ATTRIBUTE_DIRECTORY);
+                            PathRelativePathTo(szOut, path.c_str(), FILE_ATTRIBUTE_DIRECTORY, target, FILE_ATTRIBUTE_DIRECTORY);
                             std::string symlinkPath(szOut);
                             finalSymlinkPath.assign(symlinkPath);
                         }
@@ -623,12 +623,12 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
                         target.erase(0, 2);
                         target.insert(0, 2, '\\');
                         // remove last folder, see above
-                        char *pos = strrchr(path, '\\');
-                        if (pos != NULL) {
-                            *pos = '\0';
+                        size_t lastFolderIndex = path.find_last_of('\\');
+                        if (lastFolderIndex != std::string::npos) {
+                            path = path.substr(0, lastFolderIndex);
                         }
                         char szOut[MAX_PATH] = "";
-                        PathRelativePathTo(szOut, path, FILE_ATTRIBUTE_DIRECTORY, target.c_str(), FILE_ATTRIBUTE_DIRECTORY);
+                        PathRelativePathTo(szOut, path.c_str(), FILE_ATTRIBUTE_DIRECTORY, target.c_str(), FILE_ATTRIBUTE_DIRECTORY);
                         std::string symlinkPath = szOut;
                         finalSymlinkPath.assign(symlinkPath);
                     }
@@ -644,7 +644,7 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
         CloseHandle(hFile);
     }
 
-    symlink_attributes.attributes_follow = GetFileAttributesForNFS(path, &symlink_attributes.attributes);
+    symlink_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &symlink_attributes.attributes);
 
     Write(&stat);
     Write(&symlink_attributes);
@@ -657,7 +657,7 @@ nfsstat3 CNFS3Prog::ProcedureREADLINK(void)
 
 nfsstat3 CNFS3Prog::ProcedureREAD(void)
 {
-    char *path;
+    std::string path;
     offset3 offset;
     count3 count;
     post_op_attr file_attributes;
@@ -670,11 +670,11 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
     path = GetPath();
     Read(&offset);
     Read(&count);
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
     if (stat == NFS3_OK) {
         data.SetSize(count);
-        pFile = _fsopen(path, "rb", _SH_DENYWR);
+        pFile = _fsopen(path.c_str(), "rb", _SH_DENYWR);
 
         if (pFile != NULL) {
             _fseeki64(pFile, offset, SEEK_SET) ;
@@ -695,7 +695,7 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
         }
     }
 
-    file_attributes.attributes_follow = GetFileAttributesForNFS(path, &file_attributes.attributes);
+    file_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_attributes.attributes);
 
     Write(&stat);
     Write(&file_attributes);
@@ -711,7 +711,7 @@ nfsstat3 CNFS3Prog::ProcedureREAD(void)
 
 nfsstat3 CNFS3Prog::ProcedureWRITE(void)
 {
-    char *path;
+    std::string path;
     offset3 offset;
     count3 count;
     stable_how stable;
@@ -727,19 +727,19 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
     Read(&count);
     Read(&stable);
     Read(&data);
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
-    file_wcc.before.attributes_follow = GetFileAttributesForNFS(path, &file_wcc.before.attributes);
+    file_wcc.before.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.before.attributes);
 
     if (stat == NFS3_OK) {
 
         if (stable == UNSTABLE) {
             nfs_fh3 handle;
-            GetFileHandle(path, &handle);
+            GetFileHandle(path.c_str(), &handle);
             int handleId = *(unsigned int *)handle.contents;
 
             if (unstableStorageFile.count(handleId) == 0){
-                pFile = _fsopen(path, "r+b", _SH_DENYWR);
+                pFile = _fsopen(path.c_str(), "r+b", _SH_DENYWR);
                 if (pFile != NULL) {
                     unstableStorageFile.insert(std::make_pair(handleId, pFile));
                 }
@@ -769,7 +769,7 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
             file_wcc.after.attributes_follow = file_wcc.before.attributes_follow;
         } else {
 
-            pFile = _fsopen(path, "r+b", _SH_DENYWR);
+            pFile = _fsopen(path.c_str(), "r+b", _SH_DENYWR);
 
             if (pFile != NULL) {
                 _fseeki64(pFile, offset, SEEK_SET) ;
@@ -791,7 +791,7 @@ nfsstat3 CNFS3Prog::ProcedureWRITE(void)
             stable = FILE_SYNC;
             verf = 0;
 
-            file_wcc.after.attributes_follow = GetFileAttributesForNFS(path, &file_wcc.after.attributes);
+            file_wcc.after.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.after.attributes);
         }
     }
 
@@ -1154,7 +1154,7 @@ nfsstat3 CNFS3Prog::ProcedureRENAME(void)
 nfsstat3 CNFS3Prog::ProcedureLINK(void)
 {
     PrintLog("LINK");
-    char *filePath;
+    std::string path;
     diropargs3 link;
     std::string dirName;
     std::string fileName;
@@ -1162,17 +1162,17 @@ nfsstat3 CNFS3Prog::ProcedureLINK(void)
     post_op_attr obj_attributes;
     wcc_data dir_wcc;
 
-    filePath = GetPath();
+    path = GetPath();
     ReadDirectory(dirName, fileName);
 
     char *linkFullPath = GetFullPath(dirName, fileName);
 
-    if (CreateHardLink(linkFullPath, filePath, NULL) == 0) {
+    if (CreateHardLink(linkFullPath, path.c_str(), NULL) == 0) {
         stat = NFS3ERR_IO;
     }
     stat = CheckFile(linkFullPath);
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(filePath, &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
 
         if (!obj_attributes.attributes_follow) {
             stat = NFS3ERR_IO;
@@ -1190,7 +1190,7 @@ nfsstat3 CNFS3Prog::ProcedureLINK(void)
 
 nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
 {
-    char *path;
+    std::string path;
     cookie3 cookie;
     cookieverf3 cookieverf;
     count3 count;
@@ -1210,10 +1210,10 @@ nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
     Read(&cookie);
     Read(&cookieverf);
     Read(&count);
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
     if (stat == NFS3_OK) {
-        dir_attributes.attributes_follow = GetFileAttributesForNFS(path, &dir_attributes.attributes);
+        dir_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &dir_attributes.attributes);
 
         if (!dir_attributes.attributes_follow) {
             stat = NFS3ERR_IO;
@@ -1225,7 +1225,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
 
     if (stat == NFS3_OK) {
         Write(&cookieverf);
-        sprintf_s(filePath, "%s\\*", path);
+        sprintf_s(filePath, "%s\\*", path.c_str());
         eof = true;
         handle = _findfirst(filePath, &fileinfo);
         bFollows = true;
@@ -1244,7 +1244,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
 
                 do {
                     Write(&bFollows); //value follows
-                    sprintf_s(filePath, "%s\\%s", path, fileinfo.name);
+                    sprintf_s(filePath, "%s\\%s", path.c_str(), fileinfo.name);
                     fileid = GetFileID(filePath);
                     Write(&fileid); //file id
                     name.Set(fileinfo.name);
@@ -1271,7 +1271,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIR(void)
 
 nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
 {
-    char *path;
+    std::string path;
     cookie3 cookie;
     cookieverf3 cookieverf;
     count3 dircount, maxcount;
@@ -1294,10 +1294,10 @@ nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
     Read(&cookieverf);
     Read(&dircount);
     Read(&maxcount);
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
     if (stat == NFS3_OK) {
-        dir_attributes.attributes_follow = GetFileAttributesForNFS(path, &dir_attributes.attributes);
+        dir_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &dir_attributes.attributes);
         
         if (!dir_attributes.attributes_follow) {
             stat = NFS3ERR_IO;
@@ -1309,7 +1309,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
 
     if (stat == NFS3_OK) {
         Write(&cookieverf);
-        sprintf_s(filePath, "%s\\*", path);
+        sprintf_s(filePath, "%s\\*", path.c_str());
         handle = _findfirst(filePath, &fileinfo);
         eof = true;
 
@@ -1326,7 +1326,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
 
                 do {
                     Write(&bFollows); //value follows
-                    sprintf_s(filePath, "%s\\%s", path, fileinfo.name);
+                    sprintf_s(filePath, "%s\\%s", path.c_str(), fileinfo.name);
                     fileid = GetFileID(filePath);
                     Write(&fileid); //file id
                     name.Set(fileinfo.name);
@@ -1358,7 +1358,7 @@ nfsstat3 CNFS3Prog::ProcedureREADDIRPLUS(void)
 
 nfsstat3 CNFS3Prog::ProcedureFSSTAT(void)
 {
-    char *path;
+    std::string path;
     post_op_attr obj_attributes;
     size3 tbytes, fbytes, abytes, tfiles, ffiles, afiles;
     uint32 invarsec;
@@ -1367,13 +1367,13 @@ nfsstat3 CNFS3Prog::ProcedureFSSTAT(void)
 
     PrintLog("FSSTAT");
     path = GetPath();
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(path, &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
 
         if (obj_attributes.attributes_follow
-            && GetDiskFreeSpaceEx(path, (PULARGE_INTEGER)&fbytes, (PULARGE_INTEGER)&tbytes, (PULARGE_INTEGER)&abytes)
+            && GetDiskFreeSpaceEx(path.c_str(), (PULARGE_INTEGER)&fbytes, (PULARGE_INTEGER)&tbytes, (PULARGE_INTEGER)&abytes)
             ) {
             //tfiles = 99999999999;
             //ffiles = 99999999999;
@@ -1402,7 +1402,7 @@ nfsstat3 CNFS3Prog::ProcedureFSSTAT(void)
 
 nfsstat3 CNFS3Prog::ProcedureFSINFO(void)
 {
-    char *path;
+    std::string path;
     post_op_attr obj_attributes;
     uint32 rtmax, rtpref, rtmult, wtmax, wtpref, wtmult, dtpref;
     size3 maxfilesize;
@@ -1412,10 +1412,10 @@ nfsstat3 CNFS3Prog::ProcedureFSINFO(void)
 
     PrintLog("FSINFO");
     path = GetPath();
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(path, &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
 
         if (obj_attributes.attributes_follow) {
             rtmax = 65536;
@@ -1455,7 +1455,7 @@ nfsstat3 CNFS3Prog::ProcedureFSINFO(void)
 
 nfsstat3 CNFS3Prog::ProcedurePATHCONF(void)
 {
-    char *path;
+    std::string path;
     post_op_attr obj_attributes;
     nfsstat3 stat;
     uint32 linkmax, name_max;
@@ -1463,10 +1463,10 @@ nfsstat3 CNFS3Prog::ProcedurePATHCONF(void)
 
     PrintLog("PATHCONF");
     path = GetPath();
-    stat = CheckFile(path);
+    stat = CheckFile(path.c_str());
 
     if (stat == NFS3_OK) {
-        obj_attributes.attributes_follow = GetFileAttributesForNFS(path, &obj_attributes.attributes);
+        obj_attributes.attributes_follow = GetFileAttributesForNFS(path.c_str(), &obj_attributes.attributes);
 
         if (obj_attributes.attributes_follow) {
             linkmax = 1023;
@@ -1497,7 +1497,7 @@ nfsstat3 CNFS3Prog::ProcedurePATHCONF(void)
 
 nfsstat3 CNFS3Prog::ProcedureCOMMIT(void)
 {
-    char *path;
+    std::string path;
     int handleId;
     offset3 offset;
     count3 count;
@@ -1517,7 +1517,7 @@ nfsstat3 CNFS3Prog::ProcedureCOMMIT(void)
     Read(&offset);
     Read(&count);
 
-    file_wcc.before.attributes_follow = GetFileAttributesForNFS(path, &file_wcc.before.attributes);
+    file_wcc.before.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.before.attributes);
 
     handleId = *(unsigned int*)file.contents;
 
@@ -1529,7 +1529,7 @@ nfsstat3 CNFS3Prog::ProcedureCOMMIT(void)
         stat = NFS3ERR_IO;
     }
 
-    file_wcc.after.attributes_follow = GetFileAttributesForNFS(path, &file_wcc.after.attributes);
+    file_wcc.after.attributes_follow = GetFileAttributesForNFS(path.c_str(), &file_wcc.after.attributes);
 
     Write(&stat);
     Write(&file_wcc);
@@ -1768,14 +1768,14 @@ void CNFS3Prog::Write(wcc_attr *pAttr)
     Write(&pAttr->ctime);
 }
 
-char *CNFS3Prog::GetPath(void)
+std::string CNFS3Prog::GetPath(void)
 {
     nfs_fh3 object;
-    char *path;
+    std::string path;
 
     Read(&object);
     path = GetFilePath(object.contents);
-    PrintLog(" %s ", path);
+    PrintLog(" %s ", path.c_str());
 
     return path;
 }
@@ -1793,6 +1793,7 @@ void CNFS3Prog::ReadDirectory(std::string &dirName, std::string &fileName)
 
 char *CNFS3Prog::GetFullPath(void)
 {
+    //TODO: Return std::string
     std::string dirName;
     std::string fileName;
 
@@ -1802,6 +1803,7 @@ char *CNFS3Prog::GetFullPath(void)
 
 char *CNFS3Prog::GetFullPath(std::string &dirName, std::string &fileName)
 {
+    //TODO: Return std::string
     static char fullPath[MAXPATHLEN + 1];
 
     if (dirName.size() + 1 + fileName.size() > MAXPATHLEN) {
@@ -1814,7 +1816,7 @@ char *CNFS3Prog::GetFullPath(std::string &dirName, std::string &fileName)
     return fullPath;
 }
 
-nfsstat3 CNFS3Prog::CheckFile(char *fullPath)
+nfsstat3 CNFS3Prog::CheckFile(const char *fullPath)
 {
     if (fullPath == NULL) {
         return NFS3ERR_STALE;
@@ -1828,7 +1830,7 @@ nfsstat3 CNFS3Prog::CheckFile(char *fullPath)
     return NFS3_OK;
 }
 
-nfsstat3 CNFS3Prog::CheckFile(char *directory, char *fullPath)
+nfsstat3 CNFS3Prog::CheckFile(const char *directory, const char *fullPath)
 {
     // FileExists will not work for the root of a drive, e.g. \\?\D:\, therefore check if it is a drive root with GetDriveType
     if (directory == NULL || (!FileExists(directory) && GetDriveType(directory) < 2) || fullPath == NULL) {
@@ -1842,7 +1844,7 @@ nfsstat3 CNFS3Prog::CheckFile(char *directory, char *fullPath)
     return NFS3_OK;
 }
 
-bool CNFS3Prog::GetFileHandle(char *path, nfs_fh3 *pObject)
+bool CNFS3Prog::GetFileHandle(const char *path, nfs_fh3 *pObject)
 {
 	if (!::GetFileHandle(path)) {
 		PrintLog("no filehandle(path %s)", path);
@@ -1857,7 +1859,7 @@ bool CNFS3Prog::GetFileHandle(char *path, nfs_fh3 *pObject)
     return true;
 }
 
-bool CNFS3Prog::GetFileAttributesForNFS(char *path, wcc_attr *pAttr)
+bool CNFS3Prog::GetFileAttributesForNFS(const char *path, wcc_attr *pAttr)
 {
     struct stat data;
 
@@ -1881,7 +1883,7 @@ bool CNFS3Prog::GetFileAttributesForNFS(char *path, wcc_attr *pAttr)
     return true;
 }
 
-bool CNFS3Prog::GetFileAttributesForNFS(char *path, fattr3 *pAttr)
+bool CNFS3Prog::GetFileAttributesForNFS(const char *path, fattr3 *pAttr)
 {
     DWORD fileAttr;
     BY_HANDLE_FILE_INFORMATION lpFileInformation;

--- a/src/NFS3Prog.h
+++ b/src/NFS3Prog.h
@@ -288,9 +288,8 @@ class CNFS3Prog : public CRPCProg
     private:
     int m_nResult;
 
-    std::string GetPath(void);
-    void ReadDirectory(std::string &dirName, std::string &fileName);
-    char *GetFullPath(void);
+    bool GetPath(std::string &path);
+    bool ReadDirectory(std::string &dirName, std::string &fileName);
     char *GetFullPath(std::string &dirName, std::string &fileName);
     nfsstat3 CheckFile(const char *fullPath);
     nfsstat3 CheckFile(const char *directory, const char *fullPath);

--- a/src/NFS3Prog.h
+++ b/src/NFS3Prog.h
@@ -288,15 +288,15 @@ class CNFS3Prog : public CRPCProg
     private:
     int m_nResult;
 
-    char *GetPath(void);
+    std::string GetPath(void);
     void ReadDirectory(std::string &dirName, std::string &fileName);
     char *GetFullPath(void);
     char *GetFullPath(std::string &dirName, std::string &fileName);
-    nfsstat3 CheckFile(char *fullPath);
-    nfsstat3 CheckFile(char *directory, char *fullPath);
-    bool GetFileHandle(char *path, nfs_fh3 *pObject);
-    bool GetFileAttributesForNFS(char *path, wcc_attr *pAttr);
-    bool GetFileAttributesForNFS(char *path, fattr3 *pAttr);
+    nfsstat3 CheckFile(const char *fullPath);
+    nfsstat3 CheckFile(const char *directory, const char *fullPath);
+    bool GetFileHandle(const char *path, nfs_fh3 *pObject);
+    bool GetFileAttributesForNFS(const char *path, wcc_attr *pAttr);
+    bool GetFileAttributesForNFS(const char *path, fattr3 *pAttr);
     UINT32 FileTimeToPOSIX(FILETIME ft);
     std::unordered_map<int, FILE*> unstableStorageFile;
 };


### PR DESCRIPTION
It also use const char* instead of char* for immutable strings